### PR TITLE
Fixed NPE during configuration: Integer.getInteger() does not parse ints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+---
+
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/openjdk:8-jdk-browsers
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: Load dependencies
+          command: |
+            mvn --batch-mode dependency:resolve-plugins dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+      - run:
+          name: Deploy
+          command: |
+            mvn --batch-mode --settings ./.circleci/settings.xml deploy

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.OSSRH_USERNAME}</username>
+            <password>${env.OSSRH_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!---
+Verify first that your issue/request is not already reported on GitHub.
+Also test if the latest release, and master branch are affected too.
+-->
+## Issue type
+<!--- Pick one below and delete the rest -->
+ - Bug Report
+ - Feature Idea
+ - Documentation Report
+
+## Versions
+
+- JMX Source Connector: <!--- Version of JMX connector used -->
+- Kafka-connect version: <!--- Version of kafka-connect in which the JMX connector is deployed -->
+
+## Summary
+<!--- Explain the problem briefly -->
+
+## Steps to reproduce
+<!---
+For bugs, show exactly how to reproduce the problem, using a minimal test-case.
+For new features, show how the feature would be used.
+-->
+
+<!--- Paste your connector configuration between quotes below -->
+```
+
+```
+
+## Expected result
+<!--- What did you expect to happen when running the steps above? -->
+
+## Actual result
+<!--- What actually happened? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+<!--- Describe the change, including rationale and design decisions -->
+
+<!---
+If you are fixing an existing issue, please include "Fixes #nnn" in your
+commit message and your description; but you should still explain what
+the change does.
+-->
+
+## Pull Request type
+<!--- Pick one below and delete the rest: -->
+ - Feature Pull Request
+ - Bugfix Pull Request
+ - Docs Pull Request
+
+## Additional information
+<!---
+Include additional information to help people understand the change here.
+For bugs that don't have a linked bug report, a step-by-step reproduction
+of the problem is helpful.
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Maven
+target/
+
 # IntelliJ
 .idea/
 *.iml

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at zigarn@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Submitting issue
+
+Please fill a [GitHub Issue](https://github.com/zigarn/kafka-connect-jmx/issues/new).
+
+## Submitting changes
+
+Please send a [GitHub Pull Request](https://github.com/zigarn/kafka-connect-jmx/pull/new/master).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# JMX Source Connector
+
+The JmxSourceConnector is a [Source Connector](https://docs.confluent.io/current/connect/javadocs/index.html?org/apache/kafka/connect/source/SourceConnector.html) that collects JMX metrics and push them to Kafka.
+
+## Configuration
+
+| Name                    | Type   | Importance | Default Value | Validator | Documentation                                            |
+| ----------------------- | ------ | ---------- | ------------- | --------- | ---------------------------------------------------------|
+| `topic`                 | String | High       |               |           | The topic to publish data to                             |
+| `jmx.url`               | String | High       |               |           | The JMX URL to fetch data from                           |
+| `jmx.username`          | String | Medium     | `""`          |           | The username to connect to JMX                           |
+| `jmx.password`          | String | Medium     | `[hidden]`    |           | The password to connect to JMX                           |
+| `connection.attempts`   | Int    | Low        | `3`           | `[0,...]` | Maximum number of attempts to retrieve a JMX connection  |
+| `connection.backoff.ms` | Long   | Low        | `10 000`      | `[0,...]` | Backoff time in milliseconds between connection attempts |
+
+
+### Connect-standalone example
+
+This configuration is used typically along with [standalone mode](https://docs.confluent.io/current/connect/concepts.html#standalone-workers):
+
+```properties
+name=jmx-connector
+tasks.max=1
+
+connector.class=com.zigarn.kafka.connect.jmx.JmxSourceConnector
+topic=connect-jmx
+jmx.url=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi
+# Set the following configuration if JMX authentication is necessary
+jmx.username=jmx_user
+jmx.password=jmx_password
+```
+
+### Connect-distributed
+
+This configuration is used typically along with [distributed mode](http://docs.confluent.io/current/connect/concepts.html#distributed-workers):
+
+```json
+{
+    "name": "jmx-connector",
+    "config": {
+        "connector.class": "com.zigarn.kafka.connect.jmx.JmxSourceConnector",
+        "topic": "connect-jmx",
+        "jmx.url": "service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi",
+        "connection.attempts": 5,
+        "connection.backoff.ms": 1000
+    }
+}
+```
+
+Put this configuration in a `connector.json` file, then post it to one of the Kafka-connect workers:
+
+```shell
+curl -s -X POST -H 'Content-Type: application/json' --data @connector.json http://localhost:8083/connectors
+```
+
+## Output
+
+For each MBean available on the JMX server, a record will be sent to the configured topic with the following structure:
+
+ - key: [`Struct`](https://docs.confluent.io/current/connect/javadocs/org/apache/kafka/connect/data/Struct.html) with fields:
+   - `jmx.url`: JMX service URL the MBean was retrieved from
+   - `bean`: canonical name of the MBean
+   - `timestamp`: timestamp when the MBean was retrieved
+ - value: a map of MBean attributes with attribute name as key and String representation of attribute value as value
+
+For example:
+
+```json
+// Key
+{
+  "jmx.url":"/jndi/rmi://localhost:9999/jmxrmi",
+  "bean":"kafka.producer:client-id=confluent-control-center-heartbeat-sender-1-producer,type=producer-metrics",
+  "timestamp":1516713540685
+}
+// Value
+{
+  "connection-creation-total":"4.0",
+  "bufferpool-wait-time-total":"0.0",
+  "batch-split-total":"0.0",
+  "produce-throttle-time-max":"0.0",
+  "select-rate":"0.3663979748184665",
+  "connection-close-total":"0.0",
+  "outgoing-byte-rate":"113.48899714429699",
+  "record-send-total":"300.0",
+  "batch-size-max":"137.0",
+  "produce-throttle-time-avg":"0.0",
+  "iotime-total":"6.6670434E7",
+  "successful-authentication-total":"4.0",
+  "batch-split-rate":"0.0",
+  "io-waittime-total":"2.5733506471E11",
+  "request-rate":"0.06719075455217363",
+  "buffer-available-bytes":"3.3554432E7",
+  ...
+  "io-time-ns-avg":"90059.09090909091",
+  "compression-rate-avg":"0.9496202588081359",
+  "record-retry-rate":"0.0",
+  "request-latency-max":"104.0",
+  "record-size-max":"157.0",
+  "select-total":"2.5733506471E11",
+  "buffer-total-bytes":"3.3554432E7",
+  "batch-size-avg":"136.4"
+}
+```
+
+## Build
+
+The project can be built using [Maven](https://maven.apache.org/):
+
+```shell
+mvn clean package
+```
+
+## License
+
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+

--- a/README.md
+++ b/README.md
@@ -104,35 +104,9 @@ For example:
 }
 ```
 
-## Build
+## Further documentation
 
-The project can be built using [Maven](https://maven.apache.org/):
-
-```shell
-mvn clean package
-```
-
-## Release
-
-```shell
-mvn versions:set -DgenerateBackupPoms=false -DremoveSnapshot=true
-VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -v '\[')
-sed --in-place "s|<tag>HEAD</tag>|<tag>v${VERSION}</tag>|" pom.xml
-
-mvn clean deploy -P release
-
-git add pom.xml \
-  && git commit --message "Release v${VERSION}" \
-  && git tag --sign --message "Version v${VERSION}" v${VERSION}
-
-mvn versions:set -DgenerateBackupPoms=false -DnextSnapshot=true
-sed --in-place "s|<tag>v${VERSION}</tag>|<tag>HEAD</tag>|" pom.xml
-
-git add pom.xml \
-  && git commit --message "Next development version"
-
-git push origin HEAD v${VERSION}
-```
+Please see [documentation](docs).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The JmxSourceConnector is a [Source Connector](https://docs.confluent.io/current/connect/javadocs/index.html?org/apache/kafka/connect/source/SourceConnector.html) that collects JMX metrics and push them to Kafka.
 
+Build status: [![CircleCI](https://circleci.com/gh/zigarn/kafka-connect-jmx.svg?style=svg)](https://circleci.com/gh/zigarn/kafka-connect-jmx)
+
 ## Configuration
 
 | Name                    | Type   | Importance | Default Value | Validator | Documentation                                            |
@@ -108,6 +110,29 @@ The project can be built using [Maven](https://maven.apache.org/):
 
 ```shell
 mvn clean package
+```
+
+## Release
+
+```shell
+mvn versions:set -DgenerateBackupPoms=false -DremoveSnapshot=true
+VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -v '\[')
+sed --in-place "s|<tag>HEAD</tag>|<tag>v${VERSION}</tag>|" pom.xml
+
+mvn clean deploy -P release
+
+git add pom.xml \
+  && git commit --message "Release v${VERSION}" \
+  && git tag --sign --message "Version v${VERSION}" v${VERSION}
+
+mvn versions:set -DgenerateBackupPoms=false -DnextSnapshot=true
+VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -v '\[')
+sed --in-place "s|<tag>v${VERSION}</tag>|<tag>HEAD</tag>|" pom.xml
+
+git add pom.xml \
+  && git commit --message "Next development version"
+
+git push origin HEAD v${VERSION}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ git add pom.xml \
   && git tag --sign --message "Version v${VERSION}" v${VERSION}
 
 mvn versions:set -DgenerateBackupPoms=false -DnextSnapshot=true
-VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -v '\[')
 sed --in-place "s|<tag>v${VERSION}</tag>|<tag>HEAD</tag>|" pom.xml
 
 git add pom.xml \

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+## Technical documentation
+
+- [Build the connector](build.md)
+- [Release the connector](release.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,7 @@
+# Build
+
+The project can be built using [Maven](https://maven.apache.org/):
+
+```shell
+mvn clean package
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,21 @@
+# Release
+
+```shell
+mvn versions:set -DgenerateBackupPoms=false -DremoveSnapshot=true
+VERSION=$(mvn help:evaluate -Dexpression=project.version | grep -v '\[')
+sed --in-place "s|<tag>HEAD</tag>|<tag>v${VERSION}</tag>|" pom.xml
+
+mvn clean deploy -P release
+
+git add pom.xml \
+  && git commit --message "Release v${VERSION}" \
+  && git tag --sign --message "Version v${VERSION}" v${VERSION}
+
+mvn versions:set -DgenerateBackupPoms=false -DnextSnapshot=true
+sed --in-place "s|<tag>v${VERSION}</tag>|<tag>HEAD</tag>|" pom.xml
+
+git add pom.xml \
+  && git commit --message "Next development version"
+
+git push origin HEAD v${VERSION}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,90 @@
+<!--
+ Copyright 2018 Alexandre Garnier
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.zigarn.kafka.connect</groupId>
+    <artifactId>kafka-connect-jmx</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>kafka-connect-jmx</name>
+    <description>Kafka connect JMX Source Connector</description>
+    <url>https://github.com/zigarn/kafka-connect-jmx</url>
+    <inceptionYear>2018</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Alexandre Garnier</name>
+            <email>zigarn@gmail.com</email>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/zigarn/kafka-connect-jmx.git</connection>
+        <developerConnection>scm:git:git@github.com:zigarn/kafka-connect-jmx.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/zigarn/kafka-connect-jmx</url>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/zigarn/kafka-connect-jmx/issues</url>
+    </issueManagement>
+
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kafka.version>1.0.0</kafka.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     </issueManagement>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>1.1.0</kafka.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-transforms</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>1.0.0</kafka.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     </properties>
 
     <dependencies>
@@ -85,6 +89,78 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.zigarn.kafka.connect</groupId>
     <artifactId>kafka-connect-jmx</artifactId>
-    <version>0.1</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-jmx</name>
@@ -45,7 +45,7 @@
     <scm>
         <connection>scm:git:https://github.com/zigarn/kafka-connect-jmx.git</connection>
         <developerConnection>scm:git:git@github.com:zigarn/kafka-connect-jmx.git</developerConnection>
-        <tag>v0.1</tag>
+        <tag>HEAD</tag>
         <url>https://github.com/zigarn/kafka-connect-jmx</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.zigarn.kafka.connect</groupId>
     <artifactId>kafka-connect-jmx</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-jmx</name>
@@ -45,7 +45,7 @@
     <scm>
         <connection>scm:git:https://github.com/zigarn/kafka-connect-jmx.git</connection>
         <developerConnection>scm:git:git@github.com:zigarn/kafka-connect-jmx.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.1</tag>
         <url>https://github.com/zigarn/kafka-connect-jmx</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>1.0.0</kafka.version>
+        <kafka.version>1.1.0</kafka.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
@@ -67,6 +67,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>

--- a/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceConnector.java
+++ b/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceConnector.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Alexandre Garnier
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zigarn.kafka.connect.jmx;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.common.config.types.Password;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JmxSourceConnector extends SourceConnector {
+
+    public static final String TOPIC_CONFIG = "topic";
+    public static final String JMX_URL_CONF = "jmx.url";
+    public static final String JMX_USERNAME_CONF = "jmx.username";
+    public static final String JMX_PASSWORD_CONF = "jmx.password";
+    public static final String CONNECTION_ATTEMPTS_CONF = "connection.attempts";
+    public static final String CONNECTION_BACKOFF_CONF = "connection.backoff.ms";
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, "The topic to publish data to")
+            .define(JMX_URL_CONF, Type.STRING, Importance.HIGH, "The JMX URL to fetch data from")
+            .define(JMX_USERNAME_CONF, Type.STRING, "", Importance.MEDIUM, "The username to connect to JMX")
+            .define(JMX_PASSWORD_CONF, Type.PASSWORD, "", Importance.MEDIUM, "The password to connect to JMX")
+            .define(CONNECTION_ATTEMPTS_CONF, Type.INT, 3, ConfigDef.Range.atLeast(0), Importance.LOW, "Maximum number of attempts to retrieve a JMX connection")
+            .define(CONNECTION_BACKOFF_CONF, Type.LONG, 10000L, ConfigDef.Range.atLeast(0L), Importance.LOW, "Backoff time in milliseconds between connection attempts");
+
+    private String topic;
+    private String jmxUrl;
+    private String jmxUsername;
+    private Password jmxPassword;
+    private Integer maxConnectionAttempts;
+    private Long connectionRetryBackoff;
+
+    @Override
+    public String version() {
+        return JmxSourceConnector.class.getPackage().getImplementationVersion();
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        Map<String, Object> parsedProps = CONFIG_DEF.parse(props);
+        topic = (String) parsedProps.get(TOPIC_CONFIG);
+        jmxUrl = (String) parsedProps.get(JMX_URL_CONF);
+        jmxUsername = (String) parsedProps.get(JMX_USERNAME_CONF);
+        jmxPassword = (Password) parsedProps.get(JMX_PASSWORD_CONF);
+        maxConnectionAttempts = (Integer) parsedProps.get(CONNECTION_ATTEMPTS_CONF);
+        connectionRetryBackoff = (Long) parsedProps.get(CONNECTION_BACKOFF_CONF);
+        if (topic.contains(","))
+            throw new ConfigException("JmxSourceConnector should only have a single topic.");
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return JmxSourceTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        ArrayList<Map<String, String>> configs = new ArrayList<>(1);
+        // Only one JMX connection makes sense.
+        Map<String, String> config = new HashMap<>();
+        config.put(TOPIC_CONFIG, topic);
+        config.put(JMX_URL_CONF, jmxUrl);
+        config.put(JMX_USERNAME_CONF, jmxUsername);
+        config.put(JMX_PASSWORD_CONF, jmxPassword.value());
+        config.put(CONNECTION_ATTEMPTS_CONF, maxConnectionAttempts.toString());
+        config.put(CONNECTION_BACKOFF_CONF, connectionRetryBackoff.toString());
+
+        configs.add(config);
+        return configs;
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to do since JmxSourceConnector has no background monitoring.
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+}

--- a/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceTask.java
+++ b/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceTask.java
@@ -83,8 +83,8 @@ public class JmxSourceTask extends SourceTask {
             environment = new HashMap<>();
             environment.put(JMXConnector.CREDENTIALS, new String[]{jmxUsername, jmxPassword});
         }
-        maxConnectionAttempts = Integer.getInteger(props.get(JmxSourceConnector.CONNECTION_ATTEMPTS_CONF));
-        connectionRetryBackoff = Long.getLong(props.get(JmxSourceConnector.CONNECTION_BACKOFF_CONF));
+        maxConnectionAttempts = Integer.parseInt(props.get(JmxSourceConnector.CONNECTION_ATTEMPTS_CONF));
+        connectionRetryBackoff = Long.parseLong(props.get(JmxSourceConnector.CONNECTION_BACKOFF_CONF));
     }
 
     @Override

--- a/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceTask.java
+++ b/src/main/java/com/zigarn/kafka/connect/jmx/JmxSourceTask.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2018 Alexandre Garnier
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zigarn.kafka.connect.jmx;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.rmi.UnmarshalException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JmxSourceTask extends SourceTask {
+
+    private static final Logger log = LoggerFactory.getLogger(JmxSourceTask.class);
+
+    private static final String JMX_URL_FIELD = "jmx.url";
+    private static final String BEAN_FIELD = "bean";
+    private static final String TIMESTAMP_FIELD = "timestamp";
+    private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
+            .field(JMX_URL_FIELD, Schema.STRING_SCHEMA)
+            .field(BEAN_FIELD, Schema.STRING_SCHEMA)
+            .field(TIMESTAMP_FIELD, Schema.INT64_SCHEMA).build();
+    private static final Schema VALUE_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.string().optional().build());
+
+    private String topic;
+    private JMXServiceURL jmxServiceUrl;
+    private int maxConnectionAttempts;
+    private long connectionRetryBackoff;
+
+    private Map<String, Object> environment = null;
+    private JMXConnector jmxConnector = null;
+    private MBeanServerConnection mBeanServerConnection = null;
+
+    @Override
+    public String version() {
+        return new JmxSourceConnector().version();
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        topic = props.get(JmxSourceConnector.TOPIC_CONFIG);
+        if (topic == null)
+            throw new ConnectException("JmxSourceTask config missing " + JmxSourceConnector.TOPIC_CONFIG + " setting");
+        String jmxUrl = props.get(JmxSourceConnector.JMX_URL_CONF);
+        try {
+            jmxServiceUrl = new JMXServiceURL(jmxUrl);
+        } catch (MalformedURLException e) {
+            throw new ConnectException("JmxSourceTask " + JmxSourceConnector.JMX_URL_CONF + " setting malformed", e);
+        }
+        String jmxUsername = props.get(JmxSourceConnector.JMX_USERNAME_CONF);
+        String jmxPassword = props.get(JmxSourceConnector.JMX_PASSWORD_CONF);
+        if (jmxUsername != null && !jmxUsername.isEmpty()) {
+            environment = new HashMap<>();
+            environment.put(JMXConnector.CREDENTIALS, new String[]{jmxUsername, jmxPassword});
+        }
+        maxConnectionAttempts = Integer.getInteger(props.get(JmxSourceConnector.CONNECTION_ATTEMPTS_CONF));
+        connectionRetryBackoff = Long.getLong(props.get(JmxSourceConnector.CONNECTION_BACKOFF_CONF));
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+
+
+        List<SourceRecord> records = null;
+        Long timestamp = System.currentTimeMillis();
+
+        try {
+            for (ObjectName objectName : getMBeanServerConnection().queryNames(null, null)) {
+                try {
+                    MBeanInfo mBeanInfo = getMBeanServerConnection().getMBeanInfo(objectName);
+                    Map<String, String> bean = new HashMap<>();
+                    //log.trace("Getting attributes of MBean {} from JMX service {}", objectName, jmxServiceUrl);
+                    for (MBeanAttributeInfo mBeanAttributeInfo : mBeanInfo.getAttributes()) {
+                        if (!mBeanAttributeInfo.isReadable()) {
+                            continue;
+                        }
+                        try {
+                            String attributeName = mBeanAttributeInfo.getName();
+                            Object attributeValue = getMBeanServerConnection().getAttribute(objectName, attributeName);
+                            bean.put(attributeName, attributeValue == null ? null : attributeValue.toString());
+                        } catch (UnmarshalException e) {
+                            // Ignore
+                        } catch (Exception e) {
+                            if (!(e.getCause() instanceof UnsupportedOperationException)) {
+                                log.error("Failed to retrieve attribute {} of MBean {} from JMX service {}", mBeanAttributeInfo.getName(), objectName, jmxServiceUrl, e);
+                            }
+                        }
+                    }
+                    Struct key = new Struct(KEY_SCHEMA)
+                            .put(JMX_URL_FIELD, jmxServiceUrl.getURLPath())
+                            .put(BEAN_FIELD, objectName.getCanonicalName())
+                            .put(TIMESTAMP_FIELD, timestamp);
+                    SourceRecord record = new SourceRecord(null, null, topic, null,
+                            KEY_SCHEMA, key, VALUE_SCHEMA, bean, System.currentTimeMillis());
+                    if (records == null) {
+                        records = new ArrayList<>();
+                    }
+                    records.add(record);
+                } catch (Exception e) {
+                    log.error("Failed to retrieve attributes of MBean {} from JMX service {}", objectName, jmxServiceUrl, e);
+                }
+            }
+
+            return records;
+        } catch (IOException e) {
+            log.error("Failed to retrieve data from JMX service {}", jmxServiceUrl, e);
+        }
+        return null;
+    }
+
+    private synchronized MBeanServerConnection getMBeanServerConnection() throws IOException {
+        if (jmxConnector == null) {
+            newConnection();
+        } else if (!isConnectionValid()) {
+            log.info("The JMX connection is invalid. Reconnecting...");
+            closeConnection();
+            newConnection();
+        }
+        return mBeanServerConnection;
+    }
+
+    private void newConnection() throws IOException {
+        int attempts = 0;
+
+        while (true) {
+            if (attempts < maxConnectionAttempts) {
+                try {
+                    log.debug("Attempting to connect to JMX service {}", this.jmxServiceUrl);
+                    jmxConnector = JMXConnectorFactory.connect(jmxServiceUrl, environment);
+                    mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+                    return;
+                } catch (IOException e) {
+                    ++attempts;
+                    if (attempts < maxConnectionAttempts) {
+                        log.info("Unable to connect to JMX service on attempt {}/{}. Will retry in {} ms.", attempts, maxConnectionAttempts, connectionRetryBackoff, e);
+
+                        try {
+                            Thread.sleep(connectionRetryBackoff);
+                        } catch (InterruptedException ie) {
+                            // Do nothing
+                        }
+                        continue;
+                    }
+
+                    throw e;
+                }
+            }
+
+            return;
+        }
+    }
+
+    private boolean isConnectionValid() {
+        try {
+            jmxConnector.getConnectionId();
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private synchronized void closeConnection() {
+        if (jmxConnector != null) {
+            try {
+                jmxConnector.close();
+                log.trace("Closed JMXConnector");
+            } catch (IOException e) {
+                log.warn("Failed to close JmxSourceTask JMXConnector: ", e);
+            } finally {
+                jmxConnector = null;
+            }
+        }
+
+    }
+
+    @Override
+    public void stop() {
+        log.trace("Stopping");
+        closeConnection();
+    }
+
+}

--- a/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
@@ -9,8 +9,6 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
 
-import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
-
 import java.util.Map;
 
 
@@ -30,8 +28,6 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
     String FIELD_NAME = KeyToValue.FIELD_NAME;
   }
 
-  private static final String PURPOSE = "insert key into value struct";
-
   public final static String FIELD_NAME = "key.field.name";
 
 
@@ -43,7 +39,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
   @Override
   public R apply(R record)
   {
-    final Struct value = requireStruct(record.value(), PURPOSE);
+    final Map value = (Map)record.valueSchema();
 
     Schema updatedSchema = makeUpdatedSchema(record.valueSchema());
     final Struct updatedValue = new Struct(updatedSchema);

--- a/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
@@ -26,17 +26,17 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
 
   private interface ConfigName
   {
-    String FIELD_NAME = KeyToValue.FIELD_NAME;
+    String FIELD_NAME = "key.field.name";
   }
-
-  public final static String FIELD_NAME = "key.field.name";
 
   private static final String PURPOSE = "insert key into value struct";
 
+  private String fieldName;
 
   @Override
   public void configure(Map<String, ?> props)
   {
+    fieldName = (String)CONFIG_DEF.parse(props).get(ConfigName.FIELD_NAME);
   }
 
   @Override
@@ -61,7 +61,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
 
     for (Field field : updatedValue.schema().fields())
     {
-      if (field.name().equals(FIELD_NAME))
+      if (field.name().equals(fieldName))
       {
         updatedValue.put(field.name(), record.key());
       }
@@ -76,7 +76,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
   private R updateMap(R record)
   {
     Map map = (Map)record.value();
-    map.put(FIELD_NAME, record.key());
+    map.put(fieldName, record.key());
     return newRecord(record, record.valueSchema(), map);
   }
 
@@ -111,7 +111,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
     {
       builder.field(field.name(), field.schema());
     }
-    builder.field(FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA);
+    builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
 
     return builder.build();
   }

--- a/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
@@ -39,7 +39,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
   @Override
   public R apply(R record)
   {
-    final Map value = (Map)record.valueSchema();
+    final Map value = (Map)record.value();
 
     Schema updatedSchema = makeUpdatedSchema(record.valueSchema());
     final Struct updatedValue = new Struct(updatedSchema);

--- a/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
@@ -8,8 +8,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
-import org.apache.kafka.connect.transforms.util.SchemaUtil;
-import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
@@ -29,18 +27,17 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
 
   private interface ConfigName
   {
-    String FIELD_NAME = "key.field.name";
+    String FIELD_NAME = KeyToValue.FIELD_NAME;
   }
 
   private static final String PURPOSE = "insert key into value struct";
 
-  private String fieldName;
+  public final static String FIELD_NAME = "key.field.name";
+
 
   @Override
   public void configure(Map<String, ?> props)
   {
-    final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-    fieldName = config.getString(ConfigName.FIELD_NAME);
   }
 
   @Override
@@ -53,7 +50,7 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
 
     for (Field field : updatedValue.schema().fields())
     {
-      if (field.name().equals(fieldName))
+      if (field.name().equals(FIELD_NAME))
       {
         updatedValue.put(field.name(), record.key());
       }
@@ -75,12 +72,12 @@ public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
 
   private Schema makeUpdatedSchema(Schema schema)
   {
-    final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+    final SchemaBuilder builder = new SchemaBuilder(schema.type());
     for (Field field : schema.fields())
     {
       builder.field(field.name(), field.schema());
     }
-    builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
+    builder.field(FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA);
 
     return builder.build();
   }

--- a/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
+++ b/src/main/java/com/zigarn/kafka/connect/transforms/KeyToValue.java
@@ -1,0 +1,99 @@
+package com.zigarn.kafka.connect.transforms;
+
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.Map;
+
+
+public class KeyToValue<R extends ConnectRecord<R>> implements Transformation<R>
+{
+
+  public static final String OVERVIEW_DOC
+      = "Update the record's value by inserting a new column with the key of the record";
+
+  public static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(ConfigName.FIELD_NAME, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM,
+          "Field name");
+
+
+  private interface ConfigName
+  {
+    String FIELD_NAME = "key.field.name";
+  }
+
+  private static final String PURPOSE = "insert key into value struct";
+
+  private String fieldName;
+
+  @Override
+  public void configure(Map<String, ?> props)
+  {
+    final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+    fieldName = config.getString(ConfigName.FIELD_NAME);
+  }
+
+  @Override
+  public R apply(R record)
+  {
+    final Struct value = requireStruct(record.value(), PURPOSE);
+
+    Schema updatedSchema = makeUpdatedSchema(record.valueSchema());
+    final Struct updatedValue = new Struct(updatedSchema);
+
+    for (Field field : updatedValue.schema().fields())
+    {
+      if (field.name().equals(fieldName))
+      {
+        updatedValue.put(field.name(), record.key());
+      }
+      else
+      {
+        updatedValue.put(field.name(), value.get(field));
+      }
+    }
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        updatedSchema,
+        updatedValue,
+        record.timestamp()
+    );
+  }
+
+  private Schema makeUpdatedSchema(Schema schema)
+  {
+    final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+    for (Field field : schema.fields())
+    {
+      builder.field(field.name(), field.schema());
+    }
+    builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
+
+    return builder.build();
+  }
+
+  @Override
+  public void close()
+  {
+  }
+
+  @Override
+  public ConfigDef config()
+  {
+    return CONFIG_DEF;
+  }
+
+}


### PR DESCRIPTION
Fixed a NullPointerException during the initialization of the connector:

Integer.getInteger() and Long.getLong() do not parse numbers. They fetch
system-properties by the given name. Hence, they alway returned null, so
that the connector could not be configured.

I wonder, if that has ever worked...

Nevertheless, with this fix the connector works correct (at first glance).

## Summary
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

## Pull Request type
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

## Additional information
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->
